### PR TITLE
correct versioning of artefacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
       - master
       - main
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   Artefact-Version:
     runs-on: ubuntu-latest
@@ -57,15 +53,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          VERSION=${{ needs.Artefact-Version.outputs.draft_version }}
+          VERSION=${VERSION#v}
+
           gradle build publish \
-            -DAPI_SPEC_VERSION=${{ needs.Artefact-Version.outputs.draft_version }} \
+            -DAPI_SPEC_VERSION=$VERSION \
             -DGITHUB_REPOSITORY=${{ github.repository }} \
             -DGITHUB_ACTOR=${{ github.actor }} \
             -DGITHUB_TOKEN=$GITHUB_TOKEN
-
-      - name: Upload build artefacts
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.event.repository.name }}-jar
-          path: build/libs/


### PR DESCRIPTION
'v' was being added incorrectly to the version associated to the published artefact.